### PR TITLE
Add templates to chaos-fn.yml configuration

### DIFF
--- a/chaos-fn.yml
+++ b/chaos-fn.yml
@@ -14,3 +14,7 @@ functions:
       write_timeout: 5m30s
       read_timeout: 5m30s
       exec_timeout: 5m30s
+configuration:
+  templates:
+    - name: golang-middleware
+      source: https://github.com/openfaas/golang-http-template


### PR DESCRIPTION
Add golang-middleware to template configuration. 

Required for the example instructions on retries in the OpenFaaS documentation to work:
https://github.com/openfaas/docs/issues/286